### PR TITLE
@ashkan18: Refactor from inheritance to composition

### DIFF
--- a/lib/artsy-auth.rb
+++ b/lib/artsy-auth.rb
@@ -1,8 +1,8 @@
+require 'artsy-auth/authenticated'
 require 'artsy-auth/config'
 require 'artsy-auth/engine'
-require 'artsy-auth/version'
-require 'artsy-auth/application_controller'
 require 'artsy-auth/session_controller'
+require 'artsy-auth/version'
 
 module ArtsyAuth
 end

--- a/lib/artsy-auth/authenticated.rb
+++ b/lib/artsy-auth/authenticated.rb
@@ -1,6 +1,12 @@
 module ArtsyAuth
-  class ApplicationController < ActionController::Base
-    before_action :require_artsy_authentication
+  module Authenticated
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :require_artsy_authentication
+    end
+
+    private
 
     def require_artsy_authentication
       if session[:access_token]

--- a/lib/artsy-auth/session_controller.rb
+++ b/lib/artsy-auth/session_controller.rb
@@ -1,6 +1,5 @@
 module ArtsyAuth
-  class SessionsController < ApplicationController
-    skip_before_action :require_artsy_authentication
+  class SessionsController < ActionController::Base
     def create
       session[:user_id] = auth_hash['uid']
       session[:email] = auth_hash['info']['raw_info']['email']

--- a/spec/application_controller_spec.rb
+++ b/spec/application_controller_spec.rb
@@ -1,64 +1,10 @@
 require 'spec_helper'
 
 module ArtsyAuth
-  describe ApplicationController, type: :controller do
-    controller do
-      def hello_authenticated_world
-        render plain: 'Hello from authenticated world'
-      end
-    end
-    before do
-      routes.draw do
-        get 'hello_authenticated_world' => 'artsy_auth/application#hello_authenticated_world'
-      end
-    end
-    context 'without session' do
-      before do
-        get :hello_authenticated_world
-      end
-      it 'redirects to /auth/artsy' do
-        expect(response).to redirect_to('/auth/artsy')
-      end
-      it 'sets session[:redirect_to]' do
-        expect(session.key?(:redirect_to)).to be true
-      end
-    end
-    context 'with session' do
-      before do
-        session[:access_token] = 'accepted-token'
-      end
-      context 'wihtout authorized_artsy_token? method' do
-        it 'raises NotImplementedError' do
-          expect { get :hello_authenticated_world }.to raise_error NotImplementedError
-        end
-      end
-      context 'with authorized_artsy_token? method' do
-        controller do
-          def hello_authenticated_world
-            render plain: 'Hello from authenticated world'
-          end
-
-          def authorized_artsy_token?(token)
-            token == 'accepted-token'
-          end
-        end
-        before do
-          routes.draw do
-            get 'hello_authenticated_world' => 'artsy_auth/application#hello_authenticated_world'
-          end
-        end
-        it 'renders page properly with authorized token``' do
-          get :hello_authenticated_world
-          expect(response.status).to eq 200
-          expect(response.body).to eq 'Hello from authenticated world'
-        end
-
-        it 'returns forbidden with unaccepted token' do
-          session[:access_token] = 'random-token'
-          get :hello_authenticated_world
-          expect(response.status).to eq 403
-        end
-      end
+  describe ::ApplicationController, type: :controller do
+    it 'does not interfere with unauthenticated request' do
+      get :index
+      expect(response.status).to be(200)
     end
   end
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def index
+    render plain: 'Hello world'
+  end
 end

--- a/spec/dummy/app/controllers/private_controller.rb
+++ b/spec/dummy/app/controllers/private_controller.rb
@@ -1,0 +1,13 @@
+class PrivateController < ApplicationController
+  include ArtsyAuth::Authenticated
+
+  def index
+    render plain: 'Hello from authenticated world'
+  end
+
+  private
+
+  def authorized_artsy_token?(token)
+    token == 'accepted-token'
+  end
+end

--- a/spec/dummy/app/controllers/unimplemented_controller.rb
+++ b/spec/dummy/app/controllers/unimplemented_controller.rb
@@ -1,0 +1,7 @@
+class UnimplementedController < ApplicationController
+  include ArtsyAuth::Authenticated
+
+  def index
+    render plain: 'Hello from unimplemented world'
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   mount ArtsyAuth::Engine => '/'
+  get 'private' => 'private#index'
+  get 'public' => 'application#index'
+  get 'unimplemented' => 'unimplemented#index'
 end

--- a/spec/private_controller_spec.rb
+++ b/spec/private_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module ArtsyAuth
+  describe ::PrivateController, type: :controller do
+    context 'without session' do
+      it 'redirects to /auth/artsy' do
+        get :index
+        expect(response).to redirect_to('/auth/artsy')
+      end
+
+      it 'sets session[:redirect_to]' do
+        get :index
+        expect(session.key?(:redirect_to)).to be true
+      end
+    end
+
+    context 'with session' do
+      before do
+        session[:access_token] = 'accepted-token'
+      end
+
+      context 'with authorized_artsy_token? method' do
+        it 'renders page properly with authorized token``' do
+          get :index
+          expect(response.status).to eq 200
+          expect(response.body).to eq 'Hello from authenticated world'
+        end
+
+        it 'returns forbidden with unaccepted token' do
+          session[:access_token] = 'random-token'
+          get :index
+          expect(response.status).to eq 403
+        end
+      end
+    end
+  end
+end

--- a/spec/unimplemented_controller_spec.rb
+++ b/spec/unimplemented_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+module ArtsyAuth
+  describe ::UnimplementedController, type: :controller do
+    it 'raises NotImplementedError' do
+      session[:access_token] = 'accepted-token'
+      expect { get :index }.to raise_error NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
This proposes a major change in how `artsy-auth` is integrated by consuming projects. Instead of customizing base controller classes to extend `ArtsyAuth::ApplicationController`, this creates a new `ArtsyAuth::Authenticated` module that controller classes can include.

Our (@sweir27's and my) motivation was to vaguely prefer composition over inheritance, but also this came up as a practical concern when a project wanted to include [another Rails engine](https://github.com/thoughtbot/administrate) that provided base controller classes.

As part of this change, we realized that specs were testing the base controller class directly rather than the included "dummy" project. To support our new test cases, we extended the dummy project to have a few other controllers and updated specs to make assertions about how it worked.

P.S. This is a big breaking change but I think it should be considered for a pre-1.0 project. As stated in the [semantic versioning spec](http://semver.org/#spec-item-4):

> 4. Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.
