### PR TITLE
Mitigate CVE-2015-9284 (PLATFORM-3127)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,4 @@ workflows:
           matrix:
             parameters:
               ruby_version: ["2.5", "2.6", "2.7"]
-              rails_version: ["5.0.6", "5.1.4", "6.1.4"]
+              rails_version: ["5.1.4", "6.1.4"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.1.3
+
 references:
   set_env: &set_env
     run:
@@ -24,7 +27,7 @@ references:
 jobs:
   test:
     docker:
-      - image: "cimg/ruby:<< parameters.ruby_version >>"
+      - image: "cimg/ruby:<< parameters.ruby_version >>-browsers"
     parameters:
       ruby_version:
         type: string
@@ -34,6 +37,7 @@ jobs:
       RAILS_VERSION: << parameters.rails_version >>
     steps:
       - checkout
+      - browser-tools/install-chrome
       - <<: *set_env
       - <<: *bundle
       - <<: *print_versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.2.0 (Next)
+* Mitigate CVE-2015-9284 - [@starsirius](https://github.com/starsirius).
+
 ### 0.1.5 (2/2/2017)
 * Configure OmniAuth::Artsy after configuring ArtsyAuth - [@ashkan18](https://github.com/ashkan18).
 

--- a/app/views/artsy_auth/sessions/new.erb
+++ b/app/views/artsy_auth/sessions/new.erb
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Artsy Auth</title>
+  </head>
+  <body>
+    <%= button_to 'Log in via Artsy', '/auth/artsy' %>
+  </body>
+</html>

--- a/app/views/artsy_auth/sessions/new.erb
+++ b/app/views/artsy_auth/sessions/new.erb
@@ -4,10 +4,17 @@
     <meta charset="utf-8">
     <title>Artsy Auth</title>
   </head>
-  <body style="display: none;">
-    <%= button_to 'Log in via Artsy', '/auth/artsy', form: { id: 'artsy-auth-login-form' } %>
+  <body>
+    <p id="placeholder" style="visibility: hidden; text-align: center;">Authenticating...</p>
+    <div style="display: none;">
+      <%= button_to 'Log in via Artsy', '/auth/artsy', form: { id: 'artsy-auth-login-form' } %>
+    </div>
+
     <script>
-      document.getElementById('artsy-auth-login-form').submit()
+      document.getElementById("artsy-auth-login-form").submit();
+      setTimeout(function() {
+        document.getElementById("placeholder").style.visibility = "visible";
+      }, 1000);
     </script>
   </body>
 </html>

--- a/app/views/artsy_auth/sessions/new.erb
+++ b/app/views/artsy_auth/sessions/new.erb
@@ -4,7 +4,10 @@
     <meta charset="utf-8">
     <title>Artsy Auth</title>
   </head>
-  <body>
-    <%= button_to 'Log in via Artsy', '/auth/artsy' %>
+  <body style="display: none;">
+    <%= button_to 'Log in via Artsy', '/auth/artsy', form: { id: 'artsy-auth-login-form' } %>
+    <script>
+      document.getElementById('artsy-auth-login-form').submit()
+    </script>
   </body>
 </html>

--- a/artsy-auth.gemspec
+++ b/artsy-auth.gemspec
@@ -1,4 +1,6 @@
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require 'artsy-auth/version'
@@ -15,14 +17,17 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,lib}/**/*', 'Rakefile', 'README.md']
 
-  s.add_dependency 'omniauth-oauth2'
   s.add_dependency 'omniauth-artsy', '>= 0.2.2'
+  s.add_dependency 'omniauth-oauth2'
   s.add_dependency 'omniauth-rails_csrf_protection', '>= 1.0.0'
   s.add_dependency 'rails', '>= 4.2.0'
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'guard-rubocop'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'guard-rubocop'
+  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'webdrivers'
 end

--- a/artsy-auth.gemspec
+++ b/artsy-auth.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,lib}/**/*', 'Rakefile', 'README.md']
 
-  s.add_dependency 'omniauth-artsy', '>= 0.2.2'
+  s.add_dependency 'omniauth-artsy', '>= 0.4.0'
   s.add_dependency 'omniauth-oauth2'
   s.add_dependency 'omniauth-rails_csrf_protection', '>= 1.0.0'
   s.add_dependency 'rails', '>= 4.2.0'

--- a/artsy-auth.gemspec
+++ b/artsy-auth.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'omniauth-oauth2'
   s.add_dependency 'omniauth-artsy', '>= 0.2.2'
+  s.add_dependency 'omniauth-rails_csrf_protection', '>= 1.0.0'
   s.add_dependency 'rails', '>= 4.2.0'
 
   s.add_development_dependency 'rspec'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 ArtsyAuth::Engine.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
+  get '/auth/:provider/new', to: 'sessions#new'
   get '/sign_out', to: 'sessions#destroy'
 end

--- a/gemfiles/Gemfile.rails-5.0.6
+++ b/gemfiles/Gemfile.rails-5.0.6
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: ".."
-
-gem "rails", "5.0.6"

--- a/gemfiles/Gemfile.rails-5.1.4
+++ b/gemfiles/Gemfile.rails-5.1.4
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "5.1.4"
+gem "puma"

--- a/lib/artsy-auth.rb
+++ b/lib/artsy-auth.rb
@@ -3,6 +3,7 @@ require 'artsy-auth/config'
 require 'artsy-auth/engine'
 require 'artsy-auth/session_controller'
 require 'artsy-auth/version'
+require 'omniauth/rails_csrf_protection'
 
 module ArtsyAuth
 end

--- a/lib/artsy-auth/authenticated.rb
+++ b/lib/artsy-auth/authenticated.rb
@@ -19,7 +19,7 @@ module ArtsyAuth
     def clear_session_and_reauth!
       reset_session
       session[:redirect_to] = request.url
-      redirect_to '/auth/artsy'
+      redirect_to '/auth/artsy/new'
     end
 
     def authorized_artsy_token?(token)

--- a/lib/artsy-auth/session_controller.rb
+++ b/lib/artsy-auth/session_controller.rb
@@ -1,5 +1,7 @@
 module ArtsyAuth
   class SessionsController < ActionController::Base
+    def new; end
+
     def create
       session[:user_id] = auth_hash['uid']
       session[:email] = auth_hash['info']['raw_info']['email']

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   get 'private' => 'private#index'
   get 'public' => 'application#index'
   get 'unimplemented' => 'unimplemented#index'
+
+  root 'application#index'
 end

--- a/spec/mitigate_CVE-2015-9284_spec.rb
+++ b/spec/mitigate_CVE-2015-9284_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
+describe 'mitigate CVE-2015-9284', type: :request do
+  describe 'GET /auth/artsy' do
+    it 'raises no route matches error' do
+      expect do
+        get '/auth/artsy'
+      end.to raise_error(ActionController::RoutingError, 'No route matches [GET] "/auth/artsy"')
+    end
+  end
+
+  describe 'POST /auth/artsy without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+
+      # OmniAuth 2 catches exceptions and passes them to `OmniAuth.config.on_failure` handler.
+      # By default, they are passed to `FailureEndpoint` and redirected to /auth/failure. This
+      # configures the handler to re-raise the error which we verify in the test below.
+      @omniauth_on_failure = OmniAuth.config.on_failure
+      OmniAuth.config.on_failure = proc do |env|
+        raise env['omniauth.error']
+      end
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+      OmniAuth.config.on_failure = @omniauth_on_failure
+    end
+
+    it 'raises invalid authenticity token error' do
+      expect do
+        post '/auth/artsy'
+      end.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+  end
+end

--- a/spec/private_controller_spec.rb
+++ b/spec/private_controller_spec.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module ArtsyAuth
   describe ::PrivateController, type: :controller do
     context 'without session' do
-      it 'redirects to /auth/artsy' do
+      it 'redirects to /auth/artsy/new' do
         get :index
-        expect(response).to redirect_to('/auth/artsy')
+        expect(response).to redirect_to('/auth/artsy/new')
       end
 
       it 'sets session[:redirect_to]' do
@@ -20,7 +22,7 @@ module ArtsyAuth
       end
 
       context 'with authorized_artsy_token? method' do
-        it 'renders page properly with authorized token``' do
+        it 'renders page properly with authorized token' do
           get :index
           expect(response.status).to eq 200
           expect(response.body).to eq 'Hello from authenticated world'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 # Configure Rails Envinronment
 ENV['RAILS_ENV'] = 'test'
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 # frozen_string_literal: true
-#$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+# $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'rubygems'
 require 'rspec/rails'
@@ -14,4 +14,10 @@ Bundler.require(:runtime, :development)
 
 RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = true
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+  end
 end
+
+Capybara.server = :webrick

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Authentication', type: :system, js: true do
+  before do
+    allow(OmniAuth.config).to receive(:test_mode).and_return true
+    @artsy_auth = OmniAuth.config.mock_auth[:artsy]
+    OmniAuth.config.mock_auth[:artsy] = OmniAuth::AuthHash.new(
+      {
+        'uid' => 'abc',
+        'info' => { 'raw_info' => { 'email' => 'chung-yi@artsyamil.com' } },
+        'credentials' => { 'token' => 'xyz' }
+      }
+    )
+  end
+
+  after do
+    OmniAuth.config.mock_auth[:artsy] = @artsy_auth
+  end
+
+  it 'authenticates through the oauth flow' do
+    expect_any_instance_of(ArtsyAuth::SessionsController).to receive(:new).and_call_original
+    expect_any_instance_of(ArtsyAuth::SessionsController).to receive(:create).and_call_original
+
+    visit '/private'
+
+    expect(page).to have_current_path '/'
+  end
+end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3127

Depends on https://github.com/artsy/omniauth-artsy/pull/16.

This follows the [mitigation for CVE-2015-9284](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) and

- adds the `omniauth-rails_csrf_protection` gem to verify CSRF tokens for requests in OAuth request phase.
- replaces the redirection to /auth/artsy with a html form submitted by javascript.

Kinetic can probably follow the same steps to mitigate the vulnerability.

The screenshot below illustrates the sequence of the requests:

1. Access any route when unauthenticated
2. Redirect to a new route /auth/artsy/new with an invisible form
3. JavaScript submits the form immediately which `POST`s to /auth/artsy
4. The rest of OAuth flow stays the same

<img width="1680" alt="Screen Shot 2021-07-23 at 5 11 38 PM" src="https://user-images.githubusercontent.com/796573/126842012-b7956444-984e-4905-9153-0b66848aa1c2.png">


Submitting the form immediately with JavaScript should be pretty seamless, so hopefully it's not noticeable from user's perspective. The screen recording below demonstrates the new flow.

![CVE-2015-9284](https://user-images.githubusercontent.com/796573/126842062-fa988ec1-5c07-4509-a764-b995558651a2.gif)
