### PR TITLE
chore: allow other hosts on redirect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,5 +49,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby_version: ["2.5", "2.6", "2.7"]
-              rails_version: ["5.1.4", "6.1.4"]
+              ruby_version: ["2.7", "3.0", "3.1"]
+              rails_version: ["6.1.4", "7.0.8"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### 0.2.1 (Next)
+### 0.2.2 (Next)
+
+### 0.2.1 (2023-09-22)
+* Allow redirect to external hosts - [@leamotta](https://github.com/leamotta).
+* Drop testing support for Rails <6.1, Ruby <2.7. Added testing for Rails 7, Ruby 3 - [@leamotta](https://github.com/leamotta).
 
 ### 0.2.0 (2021-08-02)
 * Mitigate CVE-2015-9284 - [@starsirius](https://github.com/starsirius).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ### 0.2.2 (Next)
 
-### 0.2.1 (2023-09-22)
+### 0.2.1 (2023-09-25)
 * Allow redirect to external hosts - [@leamotta](https://github.com/leamotta).
-* Drop testing support for Rails <6.1, Ruby <2.7. Added testing for Rails 7, Ruby 3 - [@leamotta](https://github.com/leamotta).
+* Drop support for Rails <5.2. Drop testing support for Rails <6.1, Ruby <2.7. Added testing for Rails 7, Ruby 3 - [@leamotta](https://github.com/leamotta).
 
 ### 0.2.0 (2021-08-02)
 * Mitigate CVE-2015-9284 - [@starsirius](https://github.com/starsirius).

--- a/artsy-auth.gemspec
+++ b/artsy-auth.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'webdrivers'
+  s.add_development_dependency 'webrick'
 end

--- a/artsy-auth.gemspec
+++ b/artsy-auth.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'omniauth-artsy', '>= 0.4.0'
   s.add_dependency 'omniauth-oauth2'
   s.add_dependency 'omniauth-rails_csrf_protection', '>= 1.0.0'
-  s.add_dependency 'rails', '>= 4.2.0'
+  s.add_dependency 'rails', '>= 5.2.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'guard-rubocop'

--- a/gemfiles/Gemfile.rails-7.0.8
+++ b/gemfiles/Gemfile.rails-7.0.8
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "5.1.4"
-gem "puma"
+gem "rails", "7.0.8"

--- a/lib/artsy-auth/session_controller.rb
+++ b/lib/artsy-auth/session_controller.rb
@@ -11,7 +11,7 @@ module ArtsyAuth
 
     def destroy
       reset_session
-      redirect_to "#{ArtsyAuth.config.artsy_api_url}/users/sign_out"
+      redirect_to "#{ArtsyAuth.config.artsy_api_url}/users/sign_out", allow_other_host: true
     end
 
     protected

--- a/lib/artsy-auth/version.rb
+++ b/lib/artsy-auth/version.rb
@@ -1,3 +1,3 @@
 module ArtsyAuth
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -2,7 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:
 require 'action_controller/railtie'
-require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
Rails 7 [by default](https://edgeguides.rubyonrails.org/configuring.html#config-action-controller-raise-on-open-redirects) raises an error whenever there is a redirect to an external host without explicit allowance in the code.
This change allows clients that have migrated to use that default to still use the destroy/sign out endpoint seamlessly.

This option was introduced in [Rails 5.2](https://www.bigbinary.com/blog/rails-5-2-adds-allow_other_host-option-to-redirect_back-method), therefore dropping support for lower Rails versions.